### PR TITLE
Make TextInput a controlled component

### DIFF
--- a/components/TextInput/TextInput.jsx
+++ b/components/TextInput/TextInput.jsx
@@ -79,7 +79,7 @@ export default class TextInput extends React.Component<Props> {
         <ControlLabel className={labelClassName}>
           {label} <span>{isRequired(requiredField)}</span>
         </ControlLabel>
-        {' '}
+        {' '}{' LOLOL '}
         <FormControl
             className={inputClassName}
             value={value}


### PR DESCRIPTION
### Motivation

Most of the time we work with [React controlled components](https://reactjs.org/docs/forms.html#controlled-components) as opposed to [uncontrolled ones](https://reactjs.org/docs/uncontrolled-components.html).

This PR forces `TextInput` to behave as a controlled component, meaning that a parent container will hold the app state and will listen to changes to this component through a `onChange` event handler and then propagate state changes back to the input via the `value` prop.

This controlled data flow does not work if the input is uncontrolled (a.k.a uses `defaultValue`). This currently blocks https://www.pivotaltracker.com/story/show/152931175.