### PR TITLE
MonogramAvatar should support 'size' prop

### DIFF
--- a/components/Avatar/Avatar.jsx
+++ b/components/Avatar/Avatar.jsx
@@ -7,6 +7,8 @@ import {OverlayTrigger, Popover} from 'react-bootstrap'
 
 import styles from './styles.scss'
 
+export type AvatarSize = "smaller" | "small" | "base" | "large" | "larger"
+
 type Props = {
   alt: string,
   disableLink: boolean,

--- a/components/MonogramAvatar/MonogramAvatar.jsx
+++ b/components/MonogramAvatar/MonogramAvatar.jsx
@@ -7,7 +7,7 @@ import { isEmpty, map } from 'lodash'
 import styles from './monogram_avatar.scss'
 
 import Avatar from '../Avatar/Avatar'
-import AvatarSize from '../Avatar/Avatar'
+import type AvatarSize from '../Avatar/Avatar'
 
 type Props = {
   border: boolean,
@@ -75,7 +75,7 @@ class MonogramAvatar extends React.Component<Props, State> {
                 disableLink
                 onError={this.handleImageLoadError}
                 showPopover={false}
-                size={this.props.size}
+                size={size}
                 thumb={url}
             />
           </When>

--- a/components/MonogramAvatar/MonogramAvatar.jsx
+++ b/components/MonogramAvatar/MonogramAvatar.jsx
@@ -24,9 +24,9 @@ type State = {
 
 const initials = function(name: string): string {
   if (!name) {
-    return <i className="fa fa-user"></i>
+    return <i className="fa fa-user" />
   }
-  return map(name.split(/\s/), name => name[0])
+  return map(name.split(/\s/), name => name[0]).join('').substring(0,2)
 }
 
 class MonogramAvatar extends React.Component<Props, State> {

--- a/components/MonogramAvatar/MonogramAvatar.jsx
+++ b/components/MonogramAvatar/MonogramAvatar.jsx
@@ -22,9 +22,12 @@ type State = {
   showInitials: boolean
 }
 
-const initials = (name: string): string => (
-  map(name.split(/\s/), name => name[0])
-)
+const initials = function(name: string): string {
+  if (!name) {
+    return <i className="fa fa-user"></i>
+  }
+  return map(name.split(/\s/), name => name[0])
+}
 
 class MonogramAvatar extends React.Component<Props, State> {
   static defaultProps = {

--- a/components/MonogramAvatar/MonogramAvatar.jsx
+++ b/components/MonogramAvatar/MonogramAvatar.jsx
@@ -7,8 +7,7 @@ import { isEmpty, map } from 'lodash'
 import styles from './monogram_avatar.scss'
 
 import Avatar from '../Avatar/Avatar'
-
-type AvatarSize = "smaller" | "small" | "base" | "large" | "larger"
+import AvatarSize from '../Avatar/Avatar'
 
 type Props = {
   border: boolean,

--- a/components/MonogramAvatar/MonogramAvatar.jsx
+++ b/components/MonogramAvatar/MonogramAvatar.jsx
@@ -8,11 +8,14 @@ import styles from './monogram_avatar.scss'
 
 import Avatar from '../Avatar/Avatar'
 
+type AvatarSize = "smaller" | "small" | "base" | "large" | "larger"
+
 type Props = {
-  url: string,
-  personName: string,
-  className: string,
   border: boolean,
+  className: string,
+  personName: string,
+  size: AvatarSize,
+  url: string,
 }
 
 type State = {
@@ -25,7 +28,8 @@ const initials = (name: string): string => (
 
 class MonogramAvatar extends React.Component<Props, State> {
   static defaultProps = {
-    border: true
+    border: true,
+    size: 'base'
   }
   constructor(props: Props) {
     super(props)
@@ -49,6 +53,7 @@ class MonogramAvatar extends React.Component<Props, State> {
       url,
       className,
       personName,
+      size,
       border,
     } = this.props
 
@@ -68,7 +73,7 @@ class MonogramAvatar extends React.Component<Props, State> {
                 disableLink
                 onError={this.handleImageLoadError}
                 showPopover={false}
-                size={'base'}
+                size={this.props.size}
                 thumb={url}
             />
           </When>

--- a/components/MonogramAvatar/MonogramAvatarStory.jsx
+++ b/components/MonogramAvatar/MonogramAvatarStory.jsx
@@ -2,7 +2,7 @@ import React from "react"
 import MonogramAvatar from "./MonogramAvatar"
 import { withInfo } from '@storybook/addon-info'
 
-import { text, boolean } from "@storybook/addon-knobs"
+import { select, text, boolean } from "@storybook/addon-knobs"
 
 export default function MonogramAvatarStory(stories) {
   stories.add("MonogramAvatar",
@@ -11,6 +11,7 @@ export default function MonogramAvatarStory(stories) {
         const props = {
           border: boolean("border", true),
           personName: text("personName", "Jason Cypret"),
+          size: select("size", ["smaller", "small", "base", "large", "larger"], "base"),
           url: text("url", "https://s3-hq.powerhrg.com/nitro-production/avatars/32825/badge/new-face.jpg?AWSAccessKeyId=IWSW00NEQHMEYQTLZ7E9&Signature=ut0dmlR/qzvaSRoW%2BS8NU8jNh2Q%3D&Expires=3018764254"),
         }
         return <MonogramAvatar {...props}/>


### PR DESCRIPTION
Two enhancements:

1. `MonogramAvatar` should support the same `size` prop that is supported by `Avatar`. If not supplied, `size` defaults to "base", which was the old hard-coded value. That way we won't break any existing usages of `MonogramAvatar`.
2. If the user's name is blank, display the Font Awesome `fa-user` icon

We need this functionality for a JARVIS story related to CallTranscriptions. 

I expect this functionality will be useful to others in the future as well.

**Note to reviewers:** I've got limited experience with React or modern Javascript in general. Feedback is even more welcome than usual. I bet I screwed up some incredibly basic thing.