### PR TITLE
Fix panel group re-rendering issue

### DIFF
--- a/components/PanelGroup/PanelGroup.jsx
+++ b/components/PanelGroup/PanelGroup.jsx
@@ -47,7 +47,9 @@ const Panel = ({ children, collapsed, icon, name, subtitle, title, toggleIconNam
             </If>
           </BootstrapPanel.Title>
 
-          {notification}
+          <If condition={notification}>
+            {notification}
+          </If>
 
           <FontAwesome className="icon-toggle" size="lg" {...rotateProps} name={toggleIconName} />
         </BootstrapPanel.Toggle>

--- a/components/PanelGroup/PanelGroup.jsx
+++ b/components/PanelGroup/PanelGroup.jsx
@@ -29,10 +29,10 @@ type PanelGroupProps = {
 
 const Panel = ({ children, collapsed, icon, name, subtitle, title, toggleIconName, notification }: PanelProps) => {
   const rotateProps = collapsed ? { rotate: 180 } : {}
-  const panelColapsed = collapsed ? "panel-collapsed" : ""
+  const css = collapsed ? "panel-collapsed" : ""
 
   return (
-    <BootstrapPanel eventKey={name} className={panelColapsed}>
+    <BootstrapPanel eventKey={name} className={css}>
       <BootstrapPanel.Heading bsStyle="default">
         <BootstrapPanel.Toggle className="panel-toggle">
           <If condition={icon}>

--- a/components/PanelGroup/PanelGroup.jsx
+++ b/components/PanelGroup/PanelGroup.jsx
@@ -83,7 +83,9 @@ export default class PanelGroup extends React.Component<PanelGroupProps> {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState({ activePanel: nextProps.activePanel })
+    if (nextProps.activePanel !== this.props.activePanel) {
+      this.setState({ activePanel: nextProps.activePanel })
+    }
   }
 
   render() {

--- a/components/PanelGroup/PanelGroup.jsx
+++ b/components/PanelGroup/PanelGroup.jsx
@@ -87,10 +87,10 @@ export default class PanelGroup extends React.Component<PanelGroupProps> {
   }
 
   render() {
-    const { children, name, id, inner, className } = this.props
+    const { children, id, inner, className } = this.props
     const toggleIconName = inner ? "angle-up" : "caret-up"
     const panels = React.Children.map(children, (child, i) => {
-      const panelName = name || `${i}`
+      const panelName = child.props.name || `${i}`
       const collapsed = this.state.activePanel !== panelName
       return React.cloneElement(child, { name: panelName, collapsed, toggleIconName })
     })

--- a/components/PanelGroup/PanelGroupStory.jsx
+++ b/components/PanelGroup/PanelGroupStory.jsx
@@ -45,53 +45,63 @@ const dollarIcon = (
 
 export default function PanelGroupStory(stories) {
   stories.add("PanelGroup", () => {
-    const selectedPanel = "main-applicant"
-    const options = {
+    const outerActivePanelOptions = {
       ["main-applicant"]: "Main Applicant",
       ["co-applicant"]: "Co-Applicant",
     }
 
-    const props = {
-      activePanel: select("Active Panel", options, selectedPanel, "active-panel")
+    const innerActivePanelOptions = {
+      ["application-info"]: "Application Info",
+      ["contact-info"]: "Contact Information",
+      ["income-sources"]: "Income Source",
+      ["home-info"]: "Applicant Home Information",
+    }
+
+    const outerPanelGroupProps = {
+      activePanel: select("Active Outer Panel Group", outerActivePanelOptions, "main-applicant", "outer-active-panel")
+    }
+
+    const innerPanelGroupProps = {
+      activePanel: select("Active Inner Panel Group", innerActivePanelOptions, "", "outer-active-panel")
     }
 
     return (
-      <PanelGroup {...props}>
+      <PanelGroup {...outerPanelGroupProps}>
         <PanelGroup.Panel icon={largeUserIcon} name="main-applicant" title="Applicant Name" subtitle="Main Applicant" notification={ValidationIncomplete()}>
-          <PanelGroup inner>
-            <PanelGroup.Panel icon={userIcon} name="First Panel" title="Applicataion Information" notification={ValidationIncomplete()}>
+          <PanelGroup inner {...innerPanelGroupProps}>
+            <PanelGroup.Panel icon={userIcon} name="application-info" title="Application Information" notification={ValidationIncomplete()}>
               <Text>Now you see me!</Text>
             </PanelGroup.Panel>
 
-            <PanelGroup.Panel icon={phoneIcon} name="Second Panel" title="Contact Information" notification={ValidationIncomplete()}>
+            <PanelGroup.Panel icon={phoneIcon} name="contact-info" title="Contact Information" notification={ValidationIncomplete()}>
               <Text>Now you see me!</Text>
             </PanelGroup.Panel>
 
-            <PanelGroup.Panel icon={dollarIcon} name="Third Panel" title="Income Sources" notification={ValidationComplete()}>
+            <PanelGroup.Panel icon={dollarIcon} name="income-sources" title="Income Sources" notification={ValidationComplete()}>
               <Text>Now you see me!</Text>
             </PanelGroup.Panel>
 
-            <PanelGroup.Panel icon={homeIcon} name="4th Panel" title="Applicant Home Information" notification={ValidationComplete()}>
+            <PanelGroup.Panel icon={homeIcon} name="home-info" title="Applicant Home Information" notification={ValidationComplete()}>
               <Text>Now you see me!</Text>
             </PanelGroup.Panel>
           </PanelGroup>
         </PanelGroup.Panel>
 
         <PanelGroup.Panel icon={largeUserIcon} name="co-applicant" title="Co-Applicant Name" subtitle="Co-Applicant" notification={ValidationIncomplete()}>
-          <PanelGroup inner>
-            <PanelGroup.Panel icon={userIcon} name="First Panel" title="Applicataion Information" notification={ValidationIncomplete()}>
+          <PanelGroup inner {...innerPanelGroupProps}>
+            <PanelGroup.Panel icon={userIcon} name="application-info" title="Application Information" notification={ValidationIncomplete()}>
               <Text>Now you see me!</Text>
             </PanelGroup.Panel>
 
-            <PanelGroup.Panel icon={phoneIcon} name="Second Panel" title="Contact Information" notification={ValidationIncomplete()}>
+            <PanelGroup.Panel icon={phoneIcon} name="contact-info" title="Contact Information" notification={ValidationIncomplete()}>
               <Text>Now you see me!</Text>
             </PanelGroup.Panel>
 
-            <PanelGroup.Panel icon={dollarIcon} name="Third Panel" title="Income Sources" notification={ValidationComplete()}>
+            <PanelGroup.Panel icon={dollarIcon} name="income-sources" title="Income Sources" notification={ValidationComplete()}>
               <Text>Now you see me!</Text>
             </PanelGroup.Panel>
 
-            <PanelGroup.Panel icon={homeIcon} name="4th Panel" title="Applicant Home Information" notification={ValidationComplete()}>
+            <PanelGroup.Panel icon={homeIcon} name="home-info" title="Applicant Home Information" notification={ValidationComplete()}>
               <Text>Now you see me!</Text>
             </PanelGroup.Panel>
           </PanelGroup>


### PR DESCRIPTION
Prior to this fix, re-renderings triggered by a parent component would cause the PanelGroup re-render with its original props, causing it to lose its current internal state.

This PR updates `PanelGroup#componentWillReceiveProps` lifecycle callback so it checks whether or not a rerendering is necessary.

Before the fix:

![2018-04-16 10 25 52](https://user-images.githubusercontent.com/508128/38811703-9cc3f834-4160-11e8-91a2-23957d58cd04.gif)

After the fix:

![2018-04-16 10 19 37](https://user-images.githubusercontent.com/508128/38811513-17e53c04-4160-11e8-92ea-7195924a7e95.gif)
