### PR TITLE
Update FA 4 to 5 icons

### DIFF
--- a/components/FileCard/FileCard.jsx
+++ b/components/FileCard/FileCard.jsx
@@ -49,7 +49,7 @@ export default class FileCard extends React.Component<Props> {
       <Icon
           className={styles[`icon-large`]}
           label=''
-          name={`${type}-o`}
+          name={`${type}`}
           size='lg'
           title={displayName}
       />


### PR DESCRIPTION
Update Missing FileCard icons (FA5 class change)

![image](https://user-images.githubusercontent.com/1898764/42053717-ea8b785c-7ad7-11e8-8763-375160b928ea.png)
