### PR TITLE
Add rotate prop to Icon

### DIFF
--- a/components/Icon/Icon.jsx
+++ b/components/Icon/Icon.jsx
@@ -1,6 +1,9 @@
 import React from "react"
 import FontAwesome from "react-fontawesome"
+import classnames from "classnames"
 import { IconType } from "../types"
+
+import styles from "./styles.scss"
 
 /**
  * Icon renders a FontAwesome icon followed by a label.
@@ -18,6 +21,7 @@ import { IconType } from "../types"
 export default class Icon extends React.Component<Props> {
   static defaultProps = {
     label: "",
+    rotate: null,
     spin: false,
   }
   props: IconType
@@ -25,6 +29,7 @@ export default class Icon extends React.Component<Props> {
     const {
       name,
       label,
+      rotate,
       size,
       spin,
       onClick,
@@ -33,7 +38,7 @@ export default class Icon extends React.Component<Props> {
     } = this.props
     return (
       <span
-          className="icon"
+          className={classnames("icon", styles.icon, rotate ? styles[`rotate-${rotate}`] : "")}
           onClick={onClick}
           title={title}
       >

--- a/components/Icon/styles.scss
+++ b/components/Icon/styles.scss
@@ -1,0 +1,17 @@
+@import "base-mixins/_general.scss";
+
+.icon {
+    @include transition(all .2s ease-in-out);
+}
+
+.rotate {
+    &-90 {
+        @include rotate(90deg);
+    }
+    &-180 {
+        @include rotate(180deg);
+    }
+    &-270 {
+        @include rotate(270deg);
+    }
+}

--- a/components/PanelGroup/PanelGroup.jsx
+++ b/components/PanelGroup/PanelGroup.jsx
@@ -48,7 +48,9 @@ const Panel = ({ children, collapsed, icon, name, subtitle, title, toggleIconNam
           </BootstrapPanel.Title>
 
           <If condition={notification}>
-            {notification}
+            <span className="panel-heading-notification">
+              {notification}
+            </span>
           </If>
 
           <Icon className="icon-toggle" size="lg" {...rotateProps} name={toggleIconName} />

--- a/components/PanelGroup/PanelGroup.scss
+++ b/components/PanelGroup/PanelGroup.scss
@@ -11,7 +11,9 @@
 
       .panel-heading {
         background-color: $white;
-
+        &-notification {
+          margin-right: $space-large;
+        }
       }
 
       .panel-body{
@@ -61,7 +63,6 @@
           flex-direction: column;
           flex-grow: 1;
           line-height: $space-large;
-
         }
 
         .heading-icon, .title, .subtitle {
@@ -90,7 +91,6 @@
     .icon-toggle {
       color: $ink-lightest;
       transition: all 0.5s ease;
-      margin-left: $space-large;
     }
   }
 }


### PR DESCRIPTION
As of 8df688f6bc95012354f8ce0009a238dbc8b8e1c8 , the `Icon` within `PanelGroup` no longer changes on toggle of `collapsed` prop. There is also no animation.

## What does this do?

Adds `rotate` prop to `Icon.jsx` component as a FA-4 compatible temporary bridge to the [eventual upgrade to FA5 components](https://github.com/FortAwesome/react-fontawesome). 

**Note:** The work needed to upgrade is [outlined here](https://fontawesome.com/how-to-use/on-the-web/setup/upgrading-from-version-4) and is not trivial especially when considering scope. *There will need to be a story created and assigned to a Nitro Developer in order for this to be completed.*

![](http://www.reactiongifs.com/wp-content/uploads/2013/08/fml.gif)