### PR TITLE
Use React context for communicating between PanelGroup and Panel

### DIFF
--- a/components/PanelGroup/PanelGroup.jsx
+++ b/components/PanelGroup/PanelGroup.jsx
@@ -1,4 +1,5 @@
 import React from "react"
+import PropTypes from "prop-types"
 import Icon from "../Icon/Icon"
 
 import {
@@ -8,11 +9,10 @@ import {
 
 import Text from '../Text/Text'
 
-import styles from "./PanelGroup.scss"
+import "./PanelGroup.scss"
 
 type PanelProps = {
   children?: string,
-  collapsed?: boolean,
   icon?: any,
   name?: string,
   subtitle?: string,
@@ -27,7 +27,8 @@ type PanelGroupProps = {
   inner?: boolean,
 }
 
-const Panel = ({ children, collapsed, icon, name, subtitle, title, toggleIconName, notification }: PanelProps) => {
+const Panel = ({ children, icon, name = Math.random(), subtitle, title, notification }: PanelProps, context) => {
+  const collapsed = context.activePanel !== name
   const rotateProps = collapsed ? { rotate: 180 } : {}
   const css = collapsed ? "panel-collapsed" : ""
 
@@ -51,7 +52,7 @@ const Panel = ({ children, collapsed, icon, name, subtitle, title, toggleIconNam
             {notification}
           </If>
 
-          <Icon className="icon-toggle" size="lg" {...rotateProps} name={toggleIconName} />
+          <Icon className="icon-toggle" size="lg" {...rotateProps} name={context.toggleIconName} />
         </BootstrapPanel.Toggle>
       </BootstrapPanel.Heading>
 
@@ -61,49 +62,59 @@ const Panel = ({ children, collapsed, icon, name, subtitle, title, toggleIconNam
 }
 
 Panel.defaultProps = {
-  collapsed: true,
   title: "",
   toggleIconName: "chevron-up"
+}
+
+Panel.contextTypes = {
+  activePanel: PropTypes.string,
+  toggleIconName: PropTypes.string,
 }
 
 export default class PanelGroup extends React.Component<PanelGroupProps> {
   static Panel = Panel
 
+  static childContextTypes = {
+    activePanel: PropTypes.string,
+    toggleIconName: PropTypes.string,
+  }
+
   static defaultProps = {
     id: `${Math.random()}`,
     inner: false,
+    onPanelChange: () => {},
   }
 
   state = {
     activePanel: this.props.activePanel,
   }
 
-  handleSelect = (activePanel) => {
-    this.setState({ activePanel });
+  getChildContext() {
+    return {
+      activePanel: this.state.activePanel,
+      toggleIconName: this.props.inner ? "angle-up" : "chevron-down "
+    }
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.activePanel !== this.props.activePanel) {
-      this.setState({ activePanel: nextProps.activePanel })
+  handleSelect = (activePanel) => {
+    this.setState({ activePanel }, () => this.props.onPanelChange(activePanel));
+  }
+
+  componentWillReceiveProps({ activePanel }) {
+    if (activePanel !== this.props.activePanel) {
+      this.setState({ activePanel })
     }
   }
 
   render() {
     const { children, id, inner, className } = this.props
-    const toggleIconName = inner ? "angle-up" : "chevron-down "
-    const panels = React.Children.map(children, (child, i) => {
-      const panelName = child.props.name || `${i}`
-      const collapsed = this.state.activePanel !== panelName
-      return React.cloneElement(child, { name: panelName, collapsed, toggleIconName })
-    })
-
     return (
       <BootstrapPanelGroup id={id} accordion
         activeKey={this.state.activePanel}
         className={`nitro-panel-group ${className} ${inner ? "inner-panel-group": ""}`}
         onSelect={this.handleSelect}
       >
-        {panels}
+        {children}
       </BootstrapPanelGroup>
     );
   }

--- a/lib/nitro_sg/version.rb
+++ b/lib/nitro_sg/version.rb
@@ -1,3 +1,3 @@
 module NitroSg
-  VERSION = "2.1.0".freeze
+  VERSION = "2.2.0".freeze
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nitro-storybook",
-  "version": "2.0.9",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nitro-storybook",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Nitro UI Styleguide + React component dev env",
   "main": "components/index.js",
   "scripts": {


### PR DESCRIPTION
Perform communication between `PanelGroup` and `PanelGroup.Panel` via React context and remove `children` cloning and props manipulation.

Some of the use cases this will enable:

1. Have custom `PanelGroup.Panel` implementations as we now have in the new credit application
2. Allows `PanelGroup.Panel` to have many levels of ancestor components before hitting a `PanelGroup`.