### PR TITLE
Remove @extend from button group

### DIFF
--- a/lib/nitro_sg/version.rb
+++ b/lib/nitro_sg/version.rb
@@ -1,3 +1,3 @@
 module NitroSg
-  VERSION = "2.4.3".freeze
+  VERSION = "2.4.4".freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nitro-storybook",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Nitro UI Styleguide + React component dev env",
   "main": "components/index.js",
   "scripts": {

--- a/sass-mixins/nitro-ui/buttons/_button-groups.scss
+++ b/sass-mixins/nitro-ui/buttons/_button-groups.scss
@@ -90,15 +90,6 @@
 }
 
 
-// Sizing
-//
-// Remix the default button sizing classes into new ones for easier manipulation.
-
-.btn-group-xs > .btn { @extend .btn-xs; }
-.btn-group-sm > .btn { @extend .btn-sm; }
-.btn-group-lg > .btn { @extend .btn-lg; }
-
-
 // Split button dropdowns
 // ----------------------
 

--- a/sass-mixins/nitro-ui/buttons/_button-mixins.scss
+++ b/sass-mixins/nitro-ui/buttons/_button-mixins.scss
@@ -9,13 +9,13 @@
   &.btn-block + .btn-block {
     margin-top: 5px;
   }
-  &.large, &.btn-lg {
+  &.large, &.btn-lg, .btn-group > .btn {
     @include button-size($padding-large-vertical, $padding-large-horizontal, $font-large - 2px, $line-height-large, $border-rad-heavy);
   }
-  &.small, &.btn-sm {
+  &.small, &.btn-sm, .btn-group > .btn {
     @include button-size($padding-small-vertical, $padding-small-horizontal, $font-small, $line-height-small, $border-rad-light);
   }
-  &.micro, &.btn-xs {
+  &.micro, &.btn-xs, .btn-group > .btn {
     @include button-size($padding-xs-vertical, $padding-xs-horizontal, $font-smaller, $line-height-small, $border-rad-lighter);
     .fa {
       font-size: $font-smaller;


### PR DESCRIPTION
Removed @extend statements from _button-groups.scss and replaced them with group selectors in the button-mixins.scss file.