### PR TITLE
Add carousel to Nitro-Web

### DIFF
--- a/sass-mixins/nitro-ui/_all.scss
+++ b/sass-mixins/nitro-ui/_all.scss
@@ -28,3 +28,4 @@
 @import "layouts/sidebar-layout";
 @import "side-modal";
 @import "icon-toggle";
+@import "carousel";


### PR DESCRIPTION
This PR adds the Carousel functionality of Bootstrap to Nitro-Web.