### PR TITLE
Add new node and yarn versions to engines section

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
   "license": "ISC",
   "private": true,
   "engines": {
-    "node": "8.7.0",
-    "npm": "5.4.2"
+    "node": "8.7.0 || 8.9.4",
+    "npm": "5.4.2",
+    "yarn": "1.6.0 || 1.13.0"
   },
   "bugs": {
     "url": "https://github.com/powerhome/nitro-storybook/issues"


### PR DESCRIPTION
This should allow us to roll out new node and yarn versions without
impacting too much on development flow.

**NOTE** Once all devs migrate their envs to the newer versions we should be able to just drop the old versions from the engines section without impacting anyone.