### PR TITLE
Version bump for new release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nitro_sg (2.4.9)
+    nitro_sg (2.4.10)
       rails (>= 5.1.6, < 6.0)
       sassc-rails (= 1.3.0)
       sprockets-rails (= 2.3.3)
@@ -194,4 +194,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/lib/nitro_sg/version.rb
+++ b/lib/nitro_sg/version.rb
@@ -1,3 +1,3 @@
 module NitroSg
-  VERSION = "2.4.9".freeze
+  VERSION = "2.4.10".freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nitro-storybook",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "description": "Nitro UI Styleguide + React component dev env",
   "main": "components/index.js",
   "scripts": {


### PR DESCRIPTION
Update the version for a new release (missed these changes [on this PR](https://github.com/powerhome/nitro-storybook/pull/120)).