### PR TITLE
Add support to yarn 1.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nitro_sg (2.4.10)
+    nitro_sg (2.4.11)
       rails (>= 5.1.6, < 6.0)
       sassc-rails (= 1.3.0)
       sprockets-rails (= 2.3.3)

--- a/lib/nitro_sg/version.rb
+++ b/lib/nitro_sg/version.rb
@@ -1,3 +1,3 @@
 module NitroSg
-  VERSION = "2.4.10".freeze
+  VERSION = "2.4.11".freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nitro-storybook",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Nitro UI Styleguide + React component dev env",
   "main": "components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "engines": {
     "node": "8.7.0 || 8.9.4",
     "npm": "5.4.2",
-    "yarn": "1.6.0 || 1.13.0"
+    "yarn": "1.3.2 || 1.6.0 || 1.13.0"
   },
   "bugs": {
     "url": "https://github.com/powerhome/nitro-storybook/issues"


### PR DESCRIPTION
Our servers are running `yarn 1.3.2`, this PR makes sure that version is supported by this repo.