### PR TITLE
Include fonts & sass files in gem build

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nitro_sg (3.0.0)
+    nitro_sg (3.0.1)
       rails (>= 5.1.6, < 6.0)
       sassc-rails (= 1.3.0)
       sprockets-rails (= 2.3.3)

--- a/lib/nitro_sg/version.rb
+++ b/lib/nitro_sg/version.rb
@@ -1,3 +1,3 @@
 module NitroSg
-  VERSION = "3.0.0".freeze
+  VERSION = "3.0.1".freeze
 end

--- a/nitro_sg.gemspec
+++ b/nitro_sg.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.summary     = "Nitro's visual theme"
   s.description = "Nitro's visual theme, including page layout, styling and navigation"
 
-  s.files = Dir["{app,config,db,lib}/**/*"] + ["Rakefile", "README.md"]
+  s.files = Dir["{app,fonts,lib,sass-mixins}/**/*"] + ["Rakefile", "README.md"]
 
   s.add_dependency "rails", ">= 5.1.6", "< 6.0"
   s.add_dependency "sassc-rails", "1.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nitro-storybook",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Nitro UI Styleguide + React component dev env",
   "main": "components/index.js",
   "scripts": {


### PR DESCRIPTION
nitro_storybook is now a published gem at https://rubygems.org/gems/nitro_sg .

However, when trying to install this as a gem in Nitro, font and sass files were not found. Changing this configuration should include these files, making a `3.0.1` cut work.