### PR TITLE
Prep for publishing as NPM package 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nitro-storybook",
+  "name": "nitro-sg",
   "version": "3.0.2",
   "description": "Nitro UI Styleguide + React component dev env",
   "main": "components/index.js",
@@ -11,11 +11,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://github.com/powerhome/nitro-storybook.git"
+    "url": "https://github.com/powerhome/nitro-storybook.git"
   },
   "author": "powerhome",
   "license": "ISC",
-  "private": true,
   "engines": {
     "node": "8.7.0 || 8.9.4",
     "npm": "5.4.2",


### PR DESCRIPTION
1. Name the package to match the Ruby gem release name.
1. Use https for 'repository' url value
1. Remove the private specification so that the package can be publicly published (just like how the Ruby gem is publicly published).

Note: Since Nitro's `nitro-react` is currently tied to 3.0.0 version of this library directly through github,  next I will need to publish this `3.0.2` version and go into Nitro to point towards this package instead.

For the record, this is what installing storybook into Nitro looks like now:
```
"nitro-storybook": "git+https://powerhome@github.com/powerhome/nitro-storybook.git#v3.0.0",
```

and this is what installing it into Nitro would look like after renaming and publishing to npm:

```
"nitro-sg": "3.0.2",
```

Nitro currently contains about 30 places where "nitro-storybook" would need to be swapped with "nitro-sg". But every place would be a clean swap.